### PR TITLE
fix: devcontainer port setting to expose 8501 for Streamlit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     }
   },
   "portsAttributes": {
-    "5173": {
+    "8501": {
       "label": "streamlit_meetup",
       "onAutoForward": "notify"
     }


### PR DESCRIPTION
while 5173 seems to be for Vite dev server